### PR TITLE
Releases/1.1.4

### DIFF
--- a/src/commands/utility/createRoll.ts
+++ b/src/commands/utility/createRoll.ts
@@ -56,16 +56,16 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
     const user = interaction.user;
     const nickname = await fetchNickname(interaction);
     const ring = interaction.options.getNumber("ring", true);
-    const skill = interaction.options.getNumber("skill", true) ?? 0;
+    const skill = interaction.options.getNumber("skill", true) || 0;
     const voidpoint =
-      (interaction.options.getBoolean("voidpoint", false) ?? false);
+      (interaction.options.getBoolean("voidpoint", false) || false);
     const skillAssist =
-      (interaction.options.getNumber("skillassist", false) ?? 0);
+      (interaction.options.getNumber("skillassist", false) || 0);
     const unskillAssist =
-      (interaction.options.getNumber("unskillassist", false) ?? 0);
-    const TN = (interaction.options.getNumber("tn", false) ?? "?");
+      (interaction.options.getNumber("unskillassist", false) || 0);
+    const TN = (interaction.options.getNumber("tn", false) || "?");
     const label =
-      (interaction.options.getString("label", false) ?? "");
+      (interaction.options.getString("label", false) || "");
     const roll = new Roll(
       ring,
       skill,

--- a/src/commands/utility/createRoll.ts
+++ b/src/commands/utility/createRoll.ts
@@ -56,16 +56,16 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
     const user = interaction.user;
     const nickname = await fetchNickname(interaction);
     const ring = interaction.options.getNumber("ring", true);
-    const skill = interaction.options.getNumber("skill", true) || 0;
+    const skill = interaction.options.getNumber("skill", true) ?? 0;
     const voidpoint =
-      (interaction.options.getBoolean("voidpoint", false) || false);
+      (interaction.options.get("voidpoint", false)?.value as boolean) ?? false;
     const skillAssist =
-      (interaction.options.getNumber("skillassist", false) || 0);
+      (interaction.options.get("skillassist", false)?.value as number) ?? 0;
     const unskillAssist =
-      (interaction.options.getNumber("unskillassist", false) || 0);
-    const TN = (interaction.options.getNumber("tn", false) || "?");
+      (interaction.options.get("unskillassist", false)?.value as number) ?? 0;
+    const TN = (interaction.options.get("tn", false)?.value as number) ?? "?";
     const label =
-      (interaction.options.getString("label", false) || "");
+      (interaction.options.getString("label", false) || "Roll Results");
     const roll = new Roll(
       ring,
       skill,

--- a/src/commands/utility/helpCommand.ts
+++ b/src/commands/utility/helpCommand.ts
@@ -93,8 +93,8 @@ There are optional inputs for the minute if you would like to do 15 after the ho
 **NOTE:** This bot is incapable of knowing where in the world you are, so the default timezone for this is **MST (-7 UTC)**. Keep this in mind when setting a reminder.`;
       break;
     case "policies":
-      content = `**[Privacy Policy](https://github.com/sachieko/shukumei/blob/main/PRIVACYPOLICY.md) last updated on ${PRIVACYDATE}**:
-      **[Terms of Service](https://github.com/sachieko/shukumei/blob/main/TERMSOFSERVICE.md) last updated on ${TOSDATE}`;
+      content = `**[Privacy Policy](https://github.com/sachieko/shukumei/blob/main/PRIVACYPOLICY.md) last updated on ${PRIVACYDATE}**
+**[Terms of Service](https://github.com/sachieko/shukumei/blob/main/TERMSOFSERVICE.md) last updated on ${TOSDATE}**`;
       break;
     default:
       content = "Sorry that command has no help file.";
@@ -102,6 +102,6 @@ There are optional inputs for the minute if you would like to do 15 after the ho
   }
   await interaction.reply({
     content: content,
-    flags: MessageFlags.Ephemeral,
+    flags: [MessageFlags.Ephemeral, MessageFlags.SuppressEmbeds], 
   });
 };

--- a/src/commands/utility/setReminder.ts
+++ b/src/commands/utility/setReminder.ts
@@ -58,7 +58,7 @@ const command: Command = {
     }`;
     const discordString = `${
       roleToMention?.toString() ?? ""
-    } ${interaction.user.toString()}> Set a timestamp for **${eventName}** <t:${UTCstamp}:R> , <t:${UTCstamp}:F>! This time is based on your local time.`;
+    } ${interaction.user.toString()} Set a timestamp for **${eventName}** <t:${UTCstamp}:R> , <t:${UTCstamp}:F>! This time is based on your local time.`;
     await interaction.reply(discordString);
   },
 };

--- a/src/commands/utility/staredown.ts
+++ b/src/commands/utility/staredown.ts
@@ -31,10 +31,9 @@ const command: Command = {
 
   execute: async (interaction: ChatInputCommandInteraction) => {
     const target = interaction.options.getUser("opponent", true);
-    const bid = interaction.options.getNumber("bid", true);
+    const bid = interaction.options.getInteger("bid", true);
     const user = interaction.user;
-    const nickname = fetchNickname(interaction, user.id);
-    const targetNickname = fetchNickname(interaction, target.id);
+    
     // user validation
     if (target.bot) {
       await interaction.reply({
@@ -43,6 +42,7 @@ const command: Command = {
       });
       return;
     }
+    
     /* We allow users to target themselves, but may change this behavior in the future.
     if (target.user?.id === interaction.user.id) {
       
@@ -56,6 +56,7 @@ const command: Command = {
       });
       return;
     }
+    
     const bidKey = `${user.id}-${target.id}`;
     if (bidData[bidKey] !== undefined) {
       await interaction.reply({
@@ -65,6 +66,9 @@ const command: Command = {
       });
       return;
     }
+    // Fetch names after validation checks are passed.
+    const nickname = await fetchNickname(interaction, user.id);
+    const targetNickname = await fetchNickname(interaction, target.id);
     // Store staredown bid
     bidData[bidKey] = bid;
     // fetch nicknames

--- a/src/commands/utility/staredown.ts
+++ b/src/commands/utility/staredown.ts
@@ -66,7 +66,7 @@ const command: Command = {
       return;
     }
     // Store staredown bid
-    bidData[bidKey] = Number(bid);
+    bidData[bidKey] = bid;
     // fetch nicknames
     const beginBidButton = new ButtonBuilder()
       .setCustomId(`staredown-bid-${bidKey}`)

--- a/src/helpers/fetchUtils.ts
+++ b/src/helpers/fetchUtils.ts
@@ -1,7 +1,7 @@
-import { Interaction, CacheType, CommandInteraction } from "discord.js";
+import { Interaction, CacheType, ChatInputCommandInteraction } from "discord.js";
 
 export const fetchNickname = async (
-  interaction: Interaction<CacheType> | CommandInteraction,
+  interaction: Interaction<CacheType> | ChatInputCommandInteraction,
   userId?: string
 ): Promise<string> => {
   if (!interaction.guild) return "???";


### PR DESCRIPTION
## Shukumei 1.1.4 with bug fixes

Includes Privacy Policy and Terms of Service to comply with Discord requirements.

Latest:
* TN and text label inputs have been added allowing users to customize the output of their rolls more for more accurate record keeping for their games!

* Help files have been added and improved on, along with a new policies option to view the privacy policy or terms of service in compliance with discord's developer TOS.
 
* Updated intents to allow the bot to get nicknames for users in servers which should fix some names not displaying correctly in bot responses. 

* More modern methods for getting roll information are implemented, and a privacy policy and terms of service has been drafted.

Continuing to use Shukumei bot implies you acccept the terms of service and the privacy policy.

Commands:

Roll - Users can roll and modify their rolls before keeping and finalizing
Staredown - Allows users to bid strife in duel staredowns
Predict - Allows users to predict stances for duels
Reminder - Creates a timestamp in a discord channel that is local for all users to assist scheduling games
ping - Test if the bot is connected.